### PR TITLE
Fix not execution flash object

### DIFF
--- a/detect-flash.js
+++ b/detect-flash.js
@@ -39,7 +39,7 @@ export function detectFlash(swfPath, timeout = TIMEOUT) {
       resolve();
     };
 
-    swfobject.embedSWF(swfPath, el.id, '0', '0', '10.0.0');
+    swfobject.embedSWF(swfPath, el.id, '10', '10', '10.0.0');
   });
 }
 

--- a/detect-flash.js
+++ b/detect-flash.js
@@ -25,6 +25,9 @@ export function detectFlash(swfPath, timeout = TIMEOUT) {
     const wrapper = el.cloneNode();
 
     el.id = ID;
+    wrapper.style.left = '-9999px';
+    wrapper.style.top = '-9999px';
+    wrapper.style.position = 'absolute';
     wrapper.appendChild(el);
     document.body.appendChild(wrapper);
 


### PR DESCRIPTION
In Chrome 60 -, removed the final exception for PPS (Plugin Power Saver).

Ref: 
- https://www.chromium.org/flash-roadmap (PPS Tiny - No Same
Origin Exceptions (Target: Chrome 60 - Aug 2017))
- https://groups.google.com/a/chromium.org/forum/#!msg/chromium-dev/Elg7Vhpeb38/zQCvXQ_vAAAJ